### PR TITLE
Fix audit error when using non-npm package references.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [0.1.0] - 2023-04-03
 
 - Initial release
+
+## [0.6.1] - 2025-05-25
+
+- Fixed npm package auditing crashing for non-npm sourced packages.

--- a/lib/package/audit/version.rb
+++ b/lib/package/audit/version.rb
@@ -1,5 +1,5 @@
 module Package
   module Audit
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end

--- a/sig/package/audit/npm/npm_meta_data.rbs
+++ b/sig/package/audit/npm/npm_meta_data.rbs
@@ -13,6 +13,8 @@ module Package
         private
 
         def update_meta_data: (Package, Hash[Symbol, untyped]) -> void
+
+        def fetchable_packages: (Array[Package]) -> Array[Package]
       end
     end
   end


### PR DESCRIPTION
This resolves a 404 Net::HTTPNotFound exception thrown by the npm audit tool when encountering packages referenced from outside the npm registry, such as git repositories or local paths. These are valid sources but not supported by the audit API.

Fixes #25