### PR TITLE
Skip disclaimer when any format is specified.

### DIFF
--- a/lib/package/audit/services/command_parser.rb
+++ b/lib/package/audit/services/command_parser.rb
@@ -73,7 +73,7 @@ module Package
       def print_results(technology, pkgs, ignored_pkgs)
         PackagePrinter.new(@options, pkgs).print(Const::Fields::DEFAULT)
         print_summary(technology, pkgs, ignored_pkgs) unless @options[Enum::Option::FORMAT] == Enum::Format::CSV
-        print_disclaimer(technology) unless @options[Enum::Option::FORMAT] == Enum::Format::CSV || pkgs.empty?
+        print_disclaimer(technology) unless @options[Enum::Option::FORMAT] || pkgs.empty?
       end
 
       def print_summary(technology, pkgs, ignored_pkgs)


### PR DESCRIPTION
Previously, the "For more information about" disclaimer was only skipped for CSV format. Now it's skipped for any format (CSV, MD) when a format parameter is provided.