### PR TITLE
Suppress Node.js url.parse warnings from yarn audit.

### DIFF
--- a/lib/package/audit/npm/vulnerability_finder.rb
+++ b/lib/package/audit/npm/vulnerability_finder.rb
@@ -1,5 +1,6 @@
 require_relative '../const/cmd'
 require_relative '../enum/vulnerability_type'
+require 'open3'
 
 module Package
   module Audit
@@ -14,7 +15,11 @@ module Package
         end
 
         def run
-          json_string_lines = `#{format(Const::Cmd::YARN_AUDIT_JSON, @dir)}`
+          # Suppress Node.js url.parse deprecation warnings from yarn audit command
+          command = format(Const::Cmd::YARN_AUDIT_JSON, @dir)
+          env_vars = { 'NODE_NO_WARNINGS' => '1' }
+
+          json_string_lines, = Open3.capture3(env_vars, command)
           array = json_string_lines.scan(AUDIT_ADVISORY_REGEX)
 
           vulnerability_json_array = JSON.parse("[#{array.join(',')}]", symbolize_names: true)


### PR DESCRIPTION
Set NODE_NO_WARNINGS=1 when executing yarn audit to prevent DEP0169 warnings from cluttering output while preserving all functionality.