### PR TITLE
Handle private NPM packages gracefully.

### DIFF
--- a/lib/package/audit/cli.rb
+++ b/lib/package/audit/cli.rb
@@ -83,8 +83,8 @@ module Package
 
       def within_rescue_block
         yield
-        # rescue StandardError => e
-        #   exit_with_error "#{e.class}: #{e.message}"
+      rescue StandardError => e
+        exit_with_error "#{e.class}: #{e.message}"
       end
 
       def exit_with_error(msg)

--- a/lib/package/audit/cli.rb
+++ b/lib/package/audit/cli.rb
@@ -83,8 +83,8 @@ module Package
 
       def within_rescue_block
         yield
-      rescue StandardError => e
-        exit_with_error "#{e.class}: #{e.message}"
+        # rescue StandardError => e
+        #   exit_with_error "#{e.class}: #{e.message}"
       end
 
       def exit_with_error(msg)

--- a/lib/package/audit/formatter/version.rb
+++ b/lib/package/audit/formatter/version.rb
@@ -12,6 +12,8 @@ module Package
         end
 
         def format # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+          return @curr if @target.nil? # No latest version available
+
           version_parts = @curr.split('.').map(&:to_i)
           latest_version_parts = @target.split('.').map(&:to_i)
           curr_tokens = @curr.split('.')

--- a/lib/package/audit/formatter/version_date.rb
+++ b/lib/package/audit/formatter/version_date.rb
@@ -14,6 +14,8 @@ module Package
         end
 
         def format
+          return 'unknown' if @date.nil? # Handle private packages
+
           seconds_since_date = (Time.now - Time.parse(@date)).to_i
 
           if seconds_since_date >= Const::Time::SECONDS_ELAPSED_TO_BE_OUTDATED

--- a/lib/package/audit/npm/npm_meta_data.rb
+++ b/lib/package/audit/npm/npm_meta_data.rb
@@ -52,6 +52,8 @@ module Package
 
         def make_request_with_retry(package_name, retry_count)
           response = make_request(package_name)
+          return nil if response.is_a?(Net::HTTPNotFound) # Skip 404s - likely private packages
+
           raise "Unable to fetch meta data for #{package_name} from #{REGISTRY_URL} (#{response.class})" unless
             response.is_a?(Net::HTTPSuccess)
 
@@ -65,6 +67,9 @@ module Package
         end
 
         def handle_error(package, error, network_errors)
+          # Don't warn about 404s for private packages
+          return if error.is_a?(RuntimeError) && error.message.include?('(Net::HTTPNotFound)')
+
           warn "Warning: Error while fetching metadata for #{package.name}: #{error.message}"
           network_errors << error
         end
@@ -87,9 +92,31 @@ module Package
         end
 
         def update_meta_data(package, json_data)
-          latest_version = json_data[:'dist-tags'][:latest]
-          version_date = json_data[:time][package.version.to_sym]
-          latest_version_date = json_data[:time][latest_version.to_sym]
+          # No early return - let's try to get metadata even if version is unknown
+
+          latest_version = find_latest_version(json_data)
+          return unless latest_version
+
+          dates = find_version_dates(json_data, package.version, latest_version)
+          return unless dates
+
+          update_package_metadata(package, latest_version, dates)
+        end
+
+        def find_latest_version(json_data)
+          json_data[:'dist-tags']&.[](:latest)
+        end
+
+        def find_version_dates(json_data, version, latest_version)
+          version_date = json_data[:time]&.[](version.to_sym)
+          latest_version_date = json_data[:time]&.[](latest_version.to_sym)
+          return unless version_date || latest_version_date # Return if both dates are missing
+
+          [version_date || latest_version_date, latest_version_date || version_date]
+        end
+
+        def update_package_metadata(package, latest_version, dates)
+          version_date, latest_version_date = dates
           package.update version_date: Time.parse(version_date).strftime('%Y-%m-%d'),
                          latest_version: latest_version,
                          latest_version_date: Time.parse(latest_version_date).strftime('%Y-%m-%d')

--- a/lib/package/audit/npm/vulnerability_finder.rb
+++ b/lib/package/audit/npm/vulnerability_finder.rb
@@ -32,17 +32,32 @@ module Package
 
         private
 
-        def update_meta_data(json) # rubocop:disable Metrics/AbcSize
-          parent_name = json[:data][:resolution][:path].split('>').first
-          advisory = json[:data][:advisory]
-          name = advisory[:module_name]
-          version = advisory[:findings][0][:version]
-          full_name = "#{name}@#{version}"
-          vulnerability = advisory[:severity] || Enum::VulnerabilityType::UNKNOWN
+        def update_meta_data(json)
+          resolution_path = json.dig(:data, :resolution, :path)
+          return unless resolution_path # Skip if no resolution path (private package)
 
-          @vuln_hash[full_name] = Package.new(name, version, 'node') unless @vuln_hash.key? full_name
+          parent_name = resolution_path.split('>').first
+          advisory = json[:data][:advisory]
+          package_info = extract_package_info(advisory)
+          update_vulnerability_info(package_info, parent_name, advisory[:severity])
+        end
+
+        def extract_package_info(advisory)
+          {
+            name: advisory[:module_name],
+            version: advisory[:findings][0][:version]
+          }
+        end
+
+        def update_vulnerability_info(package_info, parent_name, severity)
+          name = package_info[:name]
+          version = package_info[:version]
+          full_name = "#{name}@#{version}"
+          vulnerability = severity || Enum::VulnerabilityType::UNKNOWN
+
+          @vuln_hash[full_name] ||= Package.new(name, version, 'node')
           @vuln_hash[full_name].update vulnerabilities: @vuln_hash[full_name].vulnerabilities + [vulnerability]
-          @vuln_hash[full_name].update groups: @pkg_hash[parent_name].groups.map(&:to_s)
+          @vuln_hash[full_name].update groups: @pkg_hash[parent_name]&.groups&.map(&:to_s) || []
         end
       end
     end

--- a/lib/package/audit/npm/yarn_lock_parser.rb
+++ b/lib/package/audit/npm/yarn_lock_parser.rb
@@ -100,7 +100,7 @@ module Package
                   "Unable to find the version of \"#{dep_name}\" in #{@yarn_lock_path}"
           end
 
-          version || '0.0.0.0'
+          version || 'unknown'
         end
 
         def extract_version_from_block(dep_name, pkg_block)


### PR DESCRIPTION
- Skip 404 responses from npm registry (common for private packages)
- Show "unknown" for version dates of private packages
- Continue processing other packages when private packages are encountered
- Maintain accurate counts of outdated and deprecated packages